### PR TITLE
Add Initial version of shakeshack producer and consumer

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -38,5 +38,3 @@ if __name__ == "__main__":
 
 # To dos:
 # Dockerize the application
-# Add sys argv to enable changing the image request frequency
-# Add retry logic for get request error

--- a/consumer.py
+++ b/consumer.py
@@ -1,0 +1,42 @@
+from PIL import Image
+from io import BytesIO
+import pickle
+import json
+import numpy as np
+from pykafka import KafkaClient
+from pykafka.common import OffsetType
+
+
+def gen_client(hosts="127.0.0.1:9092", topic_name='test'):
+    client = KafkaClient(hosts=hosts)
+    topic = client.topics[topic_name]
+    return client, topic
+
+
+def decode(msg):
+    msg = pickle.loads(msg)
+    img = Image.open(BytesIO(msg['img_bytes']))
+    msg['img_arr'] = np.array(img)
+    del(msg['img_bytes'])
+    return msg
+
+
+def model(msg):
+    """Call the model from here maybe"""
+    print('Request Time:', msg['req_time'],
+          'Image Dimensions:', msg['img_arr'].shape)
+
+
+if __name__ == "__main__":
+    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test')
+    consumer = topic.get_simple_consumer()
+    for msg in consumer:
+        if msg is not None:
+            msg = decode(msg.value)
+            model(msg)
+
+
+# To dos:
+# Dockerize the application
+# Add sys argv to enable changing the image request frequency
+# Add retry logic for get request error

--- a/producer_shakeshack.py
+++ b/producer_shakeshack.py
@@ -1,0 +1,68 @@
+from tornado.ioloop import IOLoop, PeriodicCallback
+import pytz
+from PIL import Image
+import requests
+from io import BytesIO
+import datetime
+import pickle
+import json
+import numpy as np
+from pykafka import KafkaClient
+from pykafka.common import OffsetType
+from functools import partial
+
+FREQUENCY_SECONDS = 60
+
+
+def get_image():
+    # timenow_et = datetime.datetime.now(pytz.timezone('America/New_York')).strftime('%Y-%m-%d-%H-%M-%S')
+    response = requests.get('http://cdn.shakeshack.com/camera.jpg')
+    return response
+
+
+def save_image():
+    response = get_image()
+    if response.status_code == 200:
+        req_time = response.headers['date'].replace(
+            ' ', '-').replace(':', '-').replace(',', '')
+        img = Image.open(BytesIO(response.content))
+        img.save(open('shakeshack_image_{}.jpg'.format(req_time), 'wb'))
+
+
+def gen_client(hosts="127.0.0.1:9092", topic_name='test'):
+    client = KafkaClient(hosts=hosts)
+    topic = client.topics[topic_name]
+    return client, topic
+
+
+def produce(topic, serialized_obj):
+    with topic.get_sync_producer() as producer:
+        producer.produce(serialized_obj)
+
+
+def pub_message(client, topic):
+    response = get_image()
+    if response.status_code == 200:
+        req_time = response.headers['date'].replace(
+            ' ', '-').replace(':', '-').replace(',', '')
+        msg = {
+            'req_time': req_time,
+            'img_bytes': response.content
+        }
+        print(len(msg['img_bytes']))
+        msg_pickle = pickle.dumps(msg)
+        produce(topic, msg_pickle)
+        print("Message published")
+
+
+if __name__ == "__main__":
+    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test')
+    print(client, topic)
+    pub_message_args = partial(pub_message, client, topic)
+    PeriodicCallback(pub_message_args, FREQUENCY_SECONDS * 1000).start()
+    IOLoop.current().start()
+
+# To dos:
+# Dockerize the application
+# Add sys argv to enable changing the image request frequency
+# Add retry logic for get request error


### PR DESCRIPTION
Created the initial files for the shakeshack producer and the consumer. The readme is yet to be added but the producer requests an image from the shakeshack camera every 60 seconds (can be changed in the producer script) and sends it to Kakfa (Kafka needs to be installed on local before the script is run). And the consumer polls the message and currently just prints the image size - the model needs to be added to this file