### PR TITLE
Add GET retry logic and check for empty response before sending msg to Kafka

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -28,7 +28,7 @@ def model(msg):
 
 
 if __name__ == "__main__":
-    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test_2')
+    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test')
     consumer = topic.get_simple_consumer()
     for msg in consumer:
         if msg is not None:

--- a/consumer.py
+++ b/consumer.py
@@ -28,7 +28,7 @@ def model(msg):
 
 
 if __name__ == "__main__":
-    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test')
+    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test_2')
     consumer = topic.get_simple_consumer()
     for msg in consumer:
         if msg is not None:
@@ -38,3 +38,4 @@ if __name__ == "__main__":
 
 # To dos:
 # Dockerize the application
+# Improve the consumer - currently it is a simple consumer

--- a/producer_shakeshack.py
+++ b/producer_shakeshack.py
@@ -16,7 +16,14 @@ FREQUENCY_SECONDS = 60
 
 def get_image():
     # timenow_et = datetime.datetime.now(pytz.timezone('America/New_York')).strftime('%Y-%m-%d-%H-%M-%S')
-    response = requests.get('http://cdn.shakeshack.com/camera.jpg')
+    retries = 10
+    success = False
+    while retries > 0 and success is False:
+        response = requests.get('http://cdn.shakeshack.com/camera.jpg')
+        if len(response.content) > 0:
+            success = True
+        retries -= 1
+    print('Retries:', 9 - retries)
     return response
 
 
@@ -42,7 +49,7 @@ def produce(topic, serialized_obj):
 
 def pub_message(client, topic):
     response = get_image()
-    if response.status_code == 200:
+    if response.status_code == 200 and len(response.content) > 0:
         req_time = response.headers['date'].replace(
             ' ', '-').replace(':', '-').replace(',', '')
         msg = {
@@ -56,7 +63,7 @@ def pub_message(client, topic):
 
 
 if __name__ == "__main__":
-    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test')
+    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test_2')
     print(client, topic)
     pub_message_args = partial(pub_message, client, topic)
     PeriodicCallback(pub_message_args, FREQUENCY_SECONDS * 1000).start()
@@ -65,4 +72,3 @@ if __name__ == "__main__":
 # To dos:
 # Dockerize the application
 # Add sys argv to enable changing the image request frequency
-# Add retry logic for get request error

--- a/producer_shakeshack.py
+++ b/producer_shakeshack.py
@@ -63,7 +63,7 @@ def pub_message(client, topic):
 
 
 if __name__ == "__main__":
-    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test_2')
+    client, topic = gen_client(hosts="127.0.0.1:9092", topic_name='test')
     print(client, topic)
     pub_message_args = partial(pub_message, client, topic)
     PeriodicCallback(pub_message_args, FREQUENCY_SECONDS * 1000).start()


### PR DESCRIPTION
The shakeshack camera service sometimes returns an empty string as the response. Added retry logic in the producer and logic to not act on any empty messages in the consumer